### PR TITLE
Default to non-AOT for runcs to broaden run-ability

### DIFF
--- a/src/Core/RemoteRunner.cs
+++ b/src/Core/RemoteRunner.cs
@@ -7,7 +7,7 @@ namespace Devlooped;
 
 public class RemoteRunner(RemoteRef location, string toolName)
 {
-    public async Task<int> RunAsync(string[] args)
+    public async Task<int> RunAsync(string[] args, bool aot)
     {
         var config = Config.Build(Config.GlobalLocation);
         var etag = config.GetString(toolName, location.ToString(), "etag");
@@ -86,11 +86,15 @@ public class RemoteRunner(RemoteRef location, string toolName)
             Process.Start(DotnetMuxer.Path.FullName, ["clean", "-v:q", program]).WaitForExit();
         }
 
+        string[] runargs = aot
+            ? ["run", "-v:q", program, .. args]
+            : ["run", "-v:q", "-p:PublishAot=false", program, .. args];
+
 #if DEBUG
-        AnsiConsole.MarkupLine($":rocket: {DotnetMuxer.Path.FullName} run -v:q {program} {string.Join(' ', args)}");
+        AnsiConsole.MarkupLine($":rocket: {DotnetMuxer.Path.FullName} {string.Join(' ', runargs)}");
 #endif
 
-        var start = new ProcessStartInfo(DotnetMuxer.Path.FullName, ["run", "-v:q", program, .. args]);
+        var start = new ProcessStartInfo(DotnetMuxer.Path.FullName, runargs);
         var process = Process.Start(start);
         process?.WaitForExit();
 

--- a/src/runcs/Properties/launchSettings.json
+++ b/src/runcs/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "args": {
       "commandName": "Project",
-      "commandLineArgs": "kzu/runcs@v0.1.0 dotnet rocks"
+      "commandLineArgs": "--aot kzu/runcs@v1 dotnet rocks"
     },
     "github": {
       "commandName": "Project",


### PR DESCRIPTION
File-based apps default to having PublishAot=true now, meaning by default things like System.Text.Json won't work OOB unless you add the source generator-based context or explicitly enable reflection-based type info.

This is not very conducive to quickly running scripts and severely limits what you can do by default. Since runcs' purpose is to RUN (but never publish/pack) apps, we turn this default off unless you explicitly opt-in with --aot switch.

See https://github.com/dotnet/sdk/issues/49189#issuecomment-2920918042