### PR TITLE
Detect temp file deletion by dnx tool and re-download

### DIFF
--- a/src/Core/RemoteRunner.cs
+++ b/src/Core/RemoteRunner.cs
@@ -46,6 +46,8 @@ public class RemoteRunner(RemoteRef location, string toolName, Config? config = 
             return 1;
         }
 
+        var program = Path.Combine(location.TempPath, location.Path ?? "program.cs");
+
         if (contents.StatusCode != HttpStatusCode.NotModified)
         {
 #if DEBUG
@@ -67,8 +69,26 @@ public class RemoteRunner(RemoteRef location, string toolName, Config? config = 
 
             updated = true;
         }
+        else if (!File.Exists(program))
+        {
+            // Redownload if etag matches but file was cleared from local cache somehow
+            contents = await provider.GetAsync(location with { ETag = null });
+            if (!contents.IsSuccessStatusCode)
+            {
+                AnsiConsole.MarkupLine($":cross_mark: Reference [yellow]{location}[/] not found.");
+                return 1;
+            }
 
-        var program = Path.Combine(location.TempPath, location.Path ?? "program.cs");
+            await contents.ExtractToAsync(location);
+
+            if (contents.Headers.ETag?.ToString() is { } newEtag &&
+                newEtag != config.GetString(toolName, location.ToString(), "etag"))
+            {
+                config = config.SetString(toolName, location.ToString(), "etag", newEtag);
+                updated = true;
+            }
+        }
+
         if (!File.Exists(program))
         {
             if (location.Path is not null)


### PR DESCRIPTION
Detect temp file deletion by dnx tool and re-download

Since we use the same temp location for files as the dotnet file programs, they might be cleaned up after a period.

We were previously not detecting this and just failing to locate the file (since we only download if saved etag didn't match). We now consider a missing local file as an implicit request to --force download and extract again.