### PR TITLE
Update NuGet package references to latest versions

### DIFF
--- a/src/Avalonia.targets
+++ b/src/Avalonia.targets
@@ -2,7 +2,7 @@
 <Project>
 
   <ItemGroup>
-    <PackageReference Include="git-credential-manager" Version="2.6.1" IncludeAssets="tools" GeneratePathProperty="true" />
+    <PackageReference Include="git-credential-manager" Version="2.7.0" IncludeAssets="tools" GeneratePathProperty="true" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(OutputType)' == 'Exe'">

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DotNetConfig" Version="1.2.0" />
     <PackageReference Include="Devlooped.CredentialManager" Version="2.7.0" Aliases="Devlooped" />
     <PackageReference Include="ThisAssembly.Project" Version="2.1.2" PrivateAssets="all" />
-    <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.7" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />
   </ItemGroup>

--- a/src/gist/gist.csproj
+++ b/src/gist/gist.csproj
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
     <PackageReference Include="ThisAssembly" Version="2.1.2" PrivateAssets="all" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Pkggit-credential-manager)' != ''">
@@ -45,7 +45,5 @@
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
   </ItemGroup>
-
-  <ProjectExtensions><VisualStudio><UserProperties properties_4launchsettings_1json__JsonSchema="https://www.schemastore.org/loobin-1.0.json" /></VisualStudio></ProjectExtensions>
 
 </Project>

--- a/src/runfile/runfile.csproj
+++ b/src/runfile/runfile.csproj
@@ -31,9 +31,9 @@
     <PackageReference Include="DotNetConfig.Configuration" Version="1.2.0" />
     <PackageReference Include="Devlooped.CredentialManager" Version="2.7.0" Aliases="Devlooped" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Spectre.Console" Version="0.54.0" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
     <PackageReference Include="ThisAssembly" Version="2.1.2" PrivateAssets="all" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.7" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Pkggit-credential-manager)' != ''">


### PR DESCRIPTION
- git-credential-manager: 2.6.1 -> 2.7.0
- Devlooped.CredentialManager: 42.42.517-main -> 2.7.0
- Spectre.Console: 0.54.0 -> 0.55.2
- System.CommandLine: 2.0.0 -> 2.0.7
- coverlet.collector: 6.0.4 -> 10.0.0
- Microsoft.NET.Test.Sdk: 18.0.1 -> 18.5.1
- Microsoft.Extensions.Configuration.*: 10.0.0 -> 10.0.7
- Remove stale VS UserProperties from gist.csproj